### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RichText
 
-Supplementary TextView for SwiftUI that provides better text selection experience, as well as enabling native view embedding using declarative syntax.
+A Supplementary TextView for SwiftUI that provides better text selection experience, as well as enabling native view embedding using declarative syntax.
 
 Powered by **TextKit 2**. Requires Xcode 26 or later to build.
 
@@ -13,13 +13,13 @@ Powered by **TextKit 2**. Requires Xcode 26 or later to build.
 
 Add **RichText** as a dependency in your Swift Package Manager manifest.
 
-```
+```swift
 .package(url: "https://github.com/LiYanan2004/RichText.git", branch: "main"),
 ```
 
 Include `RichText` in any targets that need it.
 
-```
+```swift
 .target(
     name: "MyTarget",
     dependencies: [
@@ -28,57 +28,53 @@ Include `RichText` in any targets that need it.
 ),
 ```
 
-### Strings
+### Plain String & Attributed String
 
-```
-TextView {
-    "Hello, RichText!"
-}
-```
+`TextView` provides a result builder that accepts both plain string and `AttributedString`.
 
-### Attributed Strings
-
-```
-let emphasis: AttributedString = {
-    var value = AttributedString("Important")
-    value.foregroundColor = .red
+```swift
+let packageName: AttributedString = {
+    var value = AttributedString("RichText")
+    value.foregroundColor = .blue
     value.font = .headline
     return value
 }()
 
-var body: some View {
-    TextView {
-        emphasis
-    }
-}
-```
-
-### SwiftUI `Text`
-
-`Text` values automatically resolve into attributed fragments.
-
-```
 TextView {
-    Text("Supports SwiftUI text fragments")
+    "Hello, "
+    packageName
+    "!"
 }
 ```
 
-### Inline Attachments
+### Inline SwiftUI Views
 
+You can embed SwiftUI view along with other text as well, while preserving text selection capability.
+
+Note that `SwiftUI.Text` will be resolved as **plain string** to provide normal text selection, which means:
+- string localization will be preserved
+- markdown attributes will be omitted (Use `AttributedString(markdown:)` instead.)
+
+```swift
+TextView {
+    Text("Hi, This is **RichText**.") // Resolved as "Hi, This is RichText."
+}
 ```
+
+Other SwiftUI views are added **as an individual text element**, which means text selection will either include or exclude the entire view.
+
+```swift
 TextView {
     "Tap the "
     Text("button").foregroundColor(.blue)
     " to continue "
     Image(systemName: "arrow.right.circle.fill")
 }
-```
 
-### Embedding SwiftUI Views
-
-```
 TextView {
     "Rating: "
+    
+    // The whole `HStack` will be either selected or de-selected.
     HStack(spacing: 2) {
         ForEach(0..<5) { _ in
             Image(systemName: "star.fill")


### PR DESCRIPTION
## Summary
- clarify tooling note by mentioning the Xcode requirement alongside the TextKit 2 callout
- leave only code snippets in usage sections (except for SwiftUI `Text`) and drop the redundant inline hosting example
- fix inline code formatting in the Swift Package Manager guidance

## Testing
- Not run


------
https://chatgpt.com/codex/tasks/task_b_68e34cbe5e648325afdb361755153c9a