### PR TITLE
Add support for `AttributedString.LineHeight` customization

### DIFF
--- a/Sources/RichText/Platform Specific/Text View/TextAttributeConverter.swift
+++ b/Sources/RichText/Platform Specific/Text View/TextAttributeConverter.swift
@@ -105,7 +105,7 @@ enum TextAttributeConverter {
             
             if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *),
                let lineHeight = swiftUIAttributes.lineHeight {
-                let paragraphStyle: NSMutableParagraphStyle = (convertedAttributes[.paragraphStyle] as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
+                let paragraphStyle = (attributes.paragraphStyle as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
                 
                 let (min, max, multiple) = lineHeight._lineSetting(
                     font: convertedAttributes[.font] as? PlatformFont


### PR DESCRIPTION
<img width="1231" height="1032" alt="截屏2025-10-14 00 05 47" src="https://github.com/user-attachments/assets/c338ee83-b107-4eae-b34a-ce41932df388" />
