### PR TITLE
Lower platform requirement, align truncation behavior and improve documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "RichText",
     platforms: [
-        .macOS(.v14),
-        .iOS(.v17),
+        .macOS(.v13),
+        .iOS(.v16),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Powered by **TextKit 2**.
 ## Requirements
 
 - Xcode 26.0+
-- iOS 17.0+
-- macOS 14.0+
+- iOS 16.0+
+- macOS 13.0+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ TextView {
 TextView {
     "Rating: "
     
-    // The whole `HStack` will be either selected or de-selected.
+    // The whole `HStack` will be either selected or deselected.
     HStack(spacing: 2) {
         ForEach(0..<5) { _ in
             Image(systemName: "star.fill")
@@ -102,12 +102,12 @@ TextView {
 
 #### Dynamic Views
 
-If the embeded view contains its own state, you will need to provide a unique view identifier using `.id(_:)` to bind the view's identity, otherwise, its state will be reset whenever the `textContent` is recomputed.
+If the embedded view contains its own state, you will need to provide a unique view identifier using `.id(_:)` to bind the view's identity, otherwise, its state will be reset whenever the `textContent` is recomputed.
 
 In the following example, the state of the globe icon will get reset when `ContentView.body` gets re-computed without explicit id specified.
 
 > [!TIP]
-> You may need to add `.id(_:)` view modifier directly under embeded view.
+> You may need to add `.id(_:)` view modifier directly under embedded view.
 >
 > Currently, `.id(_:)` inside `View.Body` is not recognizable.
 
@@ -155,5 +155,5 @@ If you need to customize font on older OS version, use `PlatformFont` explicitly
 
 ```swift
 TextView("TextView")
-    .font(UIFont.systemFont(ofSize: 28)) // This would work consistently across OS versions.
+    .font(PlatformFont.systemFont(ofSize: 28)) // This would work consistently across OS versions.
 ```

--- a/Sources/RichText/Attributes & Attachments/InlineHostingAttachment.swift
+++ b/Sources/RichText/Attributes & Attachments/InlineHostingAttachment.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import Introspection
 
 /// An attachment that hosts an inline SwiftUI view with other text fragments.
@@ -49,10 +50,7 @@ public final class InlineHostingAttachment: NSTextAttachment, @unchecked Sendabl
     /// ```
     public var replacement: AttributedString?
     
-    var state: State
-    @Observable
-    final class State {
-        @ObservationIgnored
+    final class State: ObservableObject {
         var size: CGSize {
             didSet {
                 guard size != oldValue else { return }
@@ -60,7 +58,7 @@ public final class InlineHostingAttachment: NSTextAttachment, @unchecked Sendabl
             }
         }
         
-        var origin: CGPoint?
+        @Published var origin: CGPoint?
         var onSizeChange: (() -> Void)?
         
         init(size: CGSize, origin: CGPoint? = nil) {
@@ -68,6 +66,7 @@ public final class InlineHostingAttachment: NSTextAttachment, @unchecked Sendabl
             self.origin = origin
         }
     }
+    var state: State
 
     @MainActor
     init<Content: View>(

--- a/Sources/RichText/Attributes & Attachments/InlineHostingAttachment.swift
+++ b/Sources/RichText/Attributes & Attachments/InlineHostingAttachment.swift
@@ -11,9 +11,9 @@ import Introspection
 
 /// An attachment that hosts an inline SwiftUI view with other text fragments.
 ///
-/// This serves as placeholder attachment to allow TextKit engine to correctly layout suroundding text.
+/// This serves as a placeholder attachment that lets TextKit lay out surrounding text.
 ///
-/// When the underlying platform text view calls its layout function, it will report the origin of all attachments back to SwiftUI view via `Observation` framework.
+/// When the platform text view lays out, it updates each attachment's origin through a Combine-backed `ObservableObject`.
 public final class InlineHostingAttachment: NSTextAttachment, @unchecked Sendable, Identifiable {
     /// The SwiftUI view hosted by the attachment.
     public var view: AnyView
@@ -35,7 +35,9 @@ public final class InlineHostingAttachment: NSTextAttachment, @unchecked Sendabl
     /// If you don't provide an id explicitly, a random UUID will be created.
     /// Whenever ``TextView`` refreshes, your view will be recreated and refreshed (all states will be reset also).
     public var id: AnyHashable
-    /// The replacement text of this view for both copy/paste and menu actions.
+    /// The replacement text of this view used for copy/paste and some menu actions.
+    ///
+    /// On AppKit, only Copy and Search with Google use the replacement; Lookup, Translate, and Share still use the original text.
     ///
     /// For example, if you copy all text from this ``TextView``, you will get "Hello **World**" (or plain text "Hello World" based on the paste location.)
     ///

--- a/Sources/RichText/Documentation.docc/Articles/better-text-selection-experience.md
+++ b/Sources/RichText/Documentation.docc/Articles/better-text-selection-experience.md
@@ -1,6 +1,6 @@
-# Better Text Selection Experience
+# Improving the text selection experience
 
-An explaination of what is better in terms of text selection experience.
+An explanation of how RichText improves text selection.
 
 @Options {
     @AutomaticArticleSubheading(disabled)
@@ -10,25 +10,25 @@ An explaination of what is better in terms of text selection experience.
     @TitleHeading("Explanation")
 }
 
-SwiftUI does offer `.textSelection(.enabled)` view modifier to enable text selection.
+SwiftUI offers the `.textSelection(.enabled)` view modifier to enable text selection.
 
 @TabNavigator {
     @Tab("SwiftUI") {        
         On macOS, it allows:
-        - Full / Partial text selection
-        - Full context menu
+        - Full and partial text selection
+        - A full context menu
         
-        however, on iOS, it ONLY allows:
+        However, on iOS, it allows only:
         - Full text selection
-        - Copy text only
+        - Copy only
         
         @Video(source: "swiftui-text-selection-on-ios.mp4", poster: "swiftui-text-selection-on-ios-poster.png")
     }
 
     @Tab("Rich Text") {
-        ``TextView`` keeps the experience that already available on macOS and fixes the experience for iOS, so you can:
-        - select partial range of text
-        - trigger more actions (e.g. Translate, Lookup, Search, etc.) in the edit menu
+        ``TextView`` preserves the experience on macOS and improves it on iOS, so you can:
+        - Select partial ranges of text
+        - Trigger more actions (for example, Translate, Lookup, and Search) in the edit menu
         
         @Video(source: "textview-text-selection-on-ios.mp4", poster: "textview-text-selection-on-ios-poster.png")
     }
@@ -36,11 +36,11 @@ SwiftUI does offer `.textSelection(.enabled)` view modifier to enable text selec
 
 ### Adopting Text View
 
-RichText offers convenience initializers for developers to instantly getting better selection experience by replacing `Text` with `TextView`:
+RichText offers convenience initializers so you can replace `Text` with `TextView` and get improved selection behavior:
 - ``TextView/init(_:tableName:bundle:comment:)``
 - ``TextView/init(verbatim:)``
 - ``TextView/init(_:)-(S)``
 - ``TextView/init(_:)-(AttributedString)``
 - ``TextView/init(_:)-(LocalizedStringResource)``
 
-> note: These initializers does not support view embeddings. If you want to embed a view, use ``TextView/init(content:)``
+> Note: These initializers do not support view embedding. If you want to embed a view, use ``TextView/init(content:)`` instead.

--- a/Sources/RichText/Documentation.docc/RichText.md
+++ b/Sources/RichText/Documentation.docc/RichText.md
@@ -14,20 +14,17 @@ RichText provides a supplementary ``TextView``, powered by **TextKit 2**, for Sw
 - ``TextView/font(_:)-(PlatformFont?)``
 - <doc:better-text-selection-experience>
 
-### Text Content
+### Providing text content
 
 - ``TextContent``
 - ``TextContentBuilder``
+- ``TextContentProviding``
 - ``LineBreak``
 - ``Space``
 - ``Tab``
 - ``InterFragment``
 
-### Embed SwiftUI View
+### Embedding SwiftUI view
 
 - ``InlineView``
 - ``InlineHostingAttachment``
-
-### Bridge Your Custom Type
-
-- ``TextContentProviding``

--- a/Sources/RichText/Platform Specific/InlineAttachmentTextView.swift
+++ b/Sources/RichText/Platform Specific/InlineAttachmentTextView.swift
@@ -206,16 +206,20 @@ extension InlineAttachmentTextView {
             }
             
             guard let segmentFrame = firstFrame else { return }
+            var origin: CGPoint?
             
-            var origin = textContainerOffset
-            origin.x += segmentFrame.origin.x
-            // align top of the view to the baseline
-            origin.y += baseline + segmentFrame.minY
-            // align the baseline of the view to the "line" baseline
-            origin.y -= attachment.ascender ?? attachment.state.size.height
-            
+            if !segmentFrame.isEmpty {
+                origin = textContainerOffset
+                origin!.x += segmentFrame.origin.x
+                // align top of the view to the baseline
+                origin!.y += baseline + segmentFrame.minY
+                // align the baseline of the view to the "line" baseline
+                origin!.y -= attachment.ascender ?? attachment.state.size.height
+            }
             if attachment.state.origin != origin {
-                attachment.state.origin = origin
+                Task { @MainActor in
+                    attachment.state.origin = origin
+                }
             }
         }
     }

--- a/Sources/RichText/Platform Specific/PlatformFontViewModifier.swift
+++ b/Sources/RichText/Platform Specific/PlatformFontViewModifier.swift
@@ -10,13 +10,13 @@ import SwiftUI
 extension SwiftUI.View {
     /// Sets the default font for the text in this view.
     ///
-    /// `SwiftUI.Font.Resolved` is only available on OS 26 and later. Starting with OS 26, `SwiftUI.Font` can be automatically resolved into `PlatformText`.
+    /// `SwiftUI.Font.Resolved` is only available on OS 26 and later, and starting with OS 26 `SwiftUI.Font` can be resolved into `PlatformFont`.
     ///
-    /// However, if you are also targeting older system versions and want to offer a consistent experience, use this view modifier to explicitly specify a platform font.
+    /// If you target older system versions and want a consistent experience, use this modifier to provide a platform font explicitly.
     ///
     /// ```swift
     /// TextView("TextView")
-    ///     .font(UIFont.systemFont(ofSize: 28)) // This would work consistently across OS versions
+    ///     .font(PlatformFont.systemFont(ofSize: 28)) // This would work consistently across OS versions
     /// ```
     @inlinable
     public nonisolated func font(_ font: PlatformFont?) -> some View {

--- a/Sources/RichText/Text Content & Fragments/Fragment Containers/View/InlineView.swift
+++ b/Sources/RichText/Text Content & Fragments/Fragment Containers/View/InlineView.swift
@@ -73,12 +73,11 @@ public struct InlineView<Content: View>: TextContentProviding {
 }
 
 extension InlineView {
-    /// Creates an instance with the given string.
-    /// Parsing it as markdown first, or fallback to plain sring.
+    /// Creates an instance with the given string and parses it as Markdown, or falls back to a plain string.
     ///
     /// If you want to use plain string as replacement, use ``init(string:content:)``.
     ///
-    /// - parameter replacement: An `String` value that will be parsed as markdown and converted into `AttributedString`, or `nil` if you don't want to create a replacement.
+    /// - parameter replacement: A `String` value that is parsed as Markdown and converted into `AttributedString`, or `nil` if you don't want to create a replacement.
     /// - parameter content: A view builder that builds the content of the view.
     /// - SeeAlso: ``init(string:content:)``
     public init(
@@ -106,7 +105,7 @@ extension InlineView {
     
     /// Creates an instance with the given string.
     ///
-    /// - parameter replacement: An `String` serves as the replacement, or `nil` if you don't want to create a replacement.
+    /// - parameter replacement: A `String` serves as the replacement, or `nil` if you don't want to create a replacement.
     /// - parameter content: A view builder that builds the content of the view.
     public init(
         string: String? = nil,

--- a/Sources/RichText/TextView.swift
+++ b/Sources/RichText/TextView.swift
@@ -80,19 +80,31 @@ public struct TextView: View {
             .overlay(alignment: .topLeading) {
                 ZStack(alignment: .topLeading) {
                     ForEach(content.attachments) { attachment in
-                        attachment.view
-                            .onGeometryChange(for: CGSize.self, of: \.size) { size in
-                                attachment.state.size = size
-                            }
-                            .offset(
-                                x: attachment.state.origin?.x ?? 0,
-                                y: attachment.state.origin?.y ?? 0
-                            )
-                            .opacity(attachment.state.origin == nil ? 0 : 1)
+                        AttachmentView(view: attachment.view, state: attachment.state)
                     }
                 }
             }
             .clipped()
+    }
+    
+    struct AttachmentView: View {
+        var view: AnyView
+        @ObservedObject var state: InlineHostingAttachment.State
+        
+        var body: some View {
+            view
+                .onGeometryChange(for: CGSize.self, of: \.size) { size in
+                    state.size = size
+                }
+                .offset(
+                    x: state.origin?.x ?? 0,
+                    y: state.origin?.y ?? 0
+                )
+                .opacity(state.origin == nil ? 0 : 1)
+                .onReceive(state.objectWillChange) { _ in
+                    print("Object changed")
+                }
+        }
     }
     
     private var _textView: some View {

--- a/Sources/RichText/TextView.swift
+++ b/Sources/RichText/TextView.swift
@@ -101,9 +101,6 @@ public struct TextView: View {
                     y: state.origin?.y ?? 0
                 )
                 .opacity(state.origin == nil ? 0 : 1)
-                .onReceive(state.objectWillChange) { _ in
-                    print("Object changed")
-                }
         }
     }
     


### PR DESCRIPTION
As title says

### Align truncation behavior

Here is a comparison of this fix:

<img alt="before" src="https://github.com/user-attachments/assets/e7ebe710-27d5-43aa-a5c1-0825bb410609" width=49%>
<img alt="after" src="https://github.com/user-attachments/assets/241e4c3b-299b-4e41-bf3c-8d0ac901bd4d" width=49%>

