### PR TITLE
Fix Copy action copying full document instead of selection in `InlineAttachmentTextView`

### DIFF
--- a/Sources/RichText/Platform Specific/InlineAttachmentTextView.swift
+++ b/Sources/RichText/Platform Specific/InlineAttachmentTextView.swift
@@ -54,12 +54,17 @@ final class InlineAttachmentTextView: PlatformTextView {
     
     // TODO: It would be better to have a way to directly modify the copying item for each attachment. `NSItemProviderWriting` is not working here.
     override func copy(_ sender: Any?) {
-        guard let documentRange = textRange(from: beginningOfDocument, to: endOfDocument) else {
+        let rangeToCopy: UITextRange
+        if let selected = selectedTextRange, !selected.isEmpty {
+            rangeToCopy = selected
+        } else if let documentRange = textRange(from: beginningOfDocument, to: endOfDocument) {
+            rangeToCopy = documentRange
+        } else {
             super.copy(sender)
             return
         }
-        
-        let attributedString = attributedText(in: documentRange)
+
+        let attributedString = attributedText(in: rangeToCopy)
         UIPasteboard.general.setObjects([attributedString])
     }
     #endif


### PR DESCRIPTION
## Summary

`InlineAttachmentTextView.copy(_:)` always built its range from
`beginningOfDocument…endOfDocument`, ignoring `selectedTextRange`. So the
in-text "Copy" menu item put the entire rich-text body on the pasteboard even
when the user had only a sentence selected.

## Fix

Prefer `selectedTextRange` when non-empty; fall back to the full document
range only when nothing is selected.